### PR TITLE
Uniformize the CI and bump the version of setup-ocaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches:
       - master
+
+env:
+  OPAMYES: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -29,14 +33,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup Ocaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
       - name: Setup GeneWeb dependencies + ocamlformat
         run: |
-          opam pin add . -y --no-action
-          opam depext -y geneweb
-          opam install -y ./*.opam --deps-only --with-test
+          opam install . --deps-only --with-test
           opam pin ocamlformat 0.24.1
       - name: Make ocamlformat > build/distrib
         run: |
@@ -67,13 +69,14 @@ jobs:
 
       - name: Setup GeneWeb dependencies
         run: |
-          opam install -y ancient calendars.1.0.0 camlp-streams camlp5 camlzip cppo dune jingoo markup ocamlformat.0.24.1 oUnit ppx_blob ppx_deriving ppx_import stdlib-shims syslog unidecode.0.2.0 uri uucp uutf uunf
+          opam install . --deps-only
+          opam install ancient
 
       - name: build/distrib
         run: |
           opam exec -- ocaml ./configure.ml --release
           opam exec -- make fmt distrib
-          
+
       - name: Run gwd with cache-in-memory parameter and check output
         run: |
           output=$(distribution/gw/gwd -cache-in-memory testing 2>&1)

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -3,6 +3,10 @@ on:
   push:
     tags:
       - v**
+
+env:
+  OCAMLYES: true
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -10,14 +14,11 @@ jobs:
       - name: checkout-code
         uses: actions/checkout@v4
       - name: setup-ocaml
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 4.14.0
       - name: setup
-        run: |
-             opam pin add . -y --no-action
-             opam depext -y geneweb
-             opam install -y ./*.opam --deps-only --with-doc
+        run: opam install . --deps-only --with-doc
       - name: build
         run: |
              opam exec -- ocaml ./configure.ml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - v**
 
+env:
+  OPAMYES: true
+
 jobs:
 
   release:
@@ -34,23 +37,20 @@ jobs:
         uses: actions/checkout@v4
 
       - name: setup-ocaml
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-version }}
 
-      - name: setup
+      - name: Setup GeneWeb dependencies + ocamlformat
         run: |
-          opam install dune ocamlformat.0.24.1
-          opam exec -- dune build @fmt
-          opam pin add . -y --no-action
-          opam depext -y geneweb
-          opam install -y ./*.opam --deps-only --with-test
+          opam install . --deps-only --with-test
+          opam pin ocamlformat 0.24.1
 
       # Build the distribution
       - name: Build the distribution
         run: |
           opam exec -- ocaml ./configure.ml --sosa-legacy --gwdb-legacy --release
-          opam exec -- make distrib
+          opam exec -- make fmt distrib
 
       # Archive distribution for release
       - name: Archive Release

--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,13 @@ endif
 	&& cat $< \
 	| cppo -n $(CPPO_D) \
 	| sed \
-	-e "s/%%%CPPO_D%%%/$(CPPO_D)/g" \
-	-e "s/%%%SOSA_PKG%%%/$(SOSA_PKG)/g" \
-	-e "s/%%%GWDB_PKG%%%/$(GWDB_PKG)/g" \
-	-e "s/%%%SYSLOG_PKG%%%/$(SYSLOG_PKG)/g" \
-	-e "s/%%%DUNE_DIRS_EXCLUDE%%%/$(DUNE_DIRS_EXCLUDE)/g" \
-	-e "s/%%%ANCIENT_LIB%%%/$(ANCIENT_LIB)/g" \
-	-e "s/%%%ANCIENT_FILE%%%/$(ANCIENT_FILE)/g" \
+	-e 's/%%%CPPO_D%%%/$(CPPO_D)/g' \
+	-e 's/%%%SOSA_PKG%%%/$(SOSA_PKG)/g' \
+	-e 's/%%%GWDB_PKG%%%/$(GWDB_PKG)/g' \
+	-e 's/%%%SYSLOG_PKG%%%/$(SYSLOG_PKG)/g' \
+	-e 's/%%%DUNE_DIRS_EXCLUDE%%%/$(DUNE_DIRS_EXCLUDE)/g' \
+	-e 's/%%%ANCIENT_LIB%%%/$(ANCIENT_LIB)/g' \
+	-e 's/%%%ANCIENT_FILE%%%/$(ANCIENT_FILE)/g' \
 	> $@ \
 	&& printf " Done.\n"
 
@@ -46,7 +46,7 @@ bin/gwrepl/.depend:
 	@printf " Done.\n"
 
 dune-workspace: dune-workspace.in Makefile.config
-	@cat $< | sed  -e "s/%%%DUNE_PROFILE%%%/$(DUNE_PROFILE)/g" > $@
+	@cat $< | sed  -e 's/%%%DUNE_PROFILE%%%/$(DUNE_PROFILE)/g' > $@
 
 COMPIL_DATE := $(shell date +'%Y-%m-%d')
 COMMIT_DATE := $(shell git show -s --date=short --pretty=format:'%cd')
@@ -60,12 +60,12 @@ OCAMLV := $(shell ocaml --version)
 
 lib/version.ml:
 	@cp lib/version.txt $@
-	@printf "let branch = \"$(BRANCH)\"\n" >> $@
-	@printf "let src = \"$(SOURCE)\"\n" >> $@
-	@printf "let commit_id = \"$(COMMIT_ID)\"\n" >> $@
-	@printf "let commit_date = \"$(COMMIT_DATE)\"\n" >> $@
-	@printf "let compil_date = \"$(COMPIL_DATE)\"\n" >> $@
-	@printf "Generating $@… Done.\n"
+	@printf 'let branch = "$(BRANCH)"\n' >> $@
+	@printf 'let src = "$(SOURCE)"\n' >> $@
+	@printf 'let commit_id = "$(COMMIT_ID)"\n' >> $@
+	@printf 'let commit_date = "$(COMMIT_DATE)"\n' >> $@
+	@printf 'let compil_date = "$(COMPIL_DATE)"\n' >> $@
+	@printf 'Generating $@… Done.\n'
 
 # Patch/unpatch files for campl5 >= 8.03
 CAMLP5_VERSION := $(shell camlp5 -version 2>/dev/null || echo 0)
@@ -73,7 +73,7 @@ CAMLP5_MAJOR := $(shell echo $(CAMLP5_VERSION) | cut -d '.' -f 1)
 CAMLP5_MINOR := $(shell echo $(CAMLP5_VERSION) | cut -d '.' -f 2)
 
 patch_files:
-	@if [ "$(CAMLP5_VERSION)" != 0 ] && [ $(CAMLP5_MAJOR) -eq 8 ] && [ $(CAMLP5_MINOR) -ge 3 ]; then \
+	@if [ '$(CAMLP5_VERSION)' != 0 ] && [ $(CAMLP5_MAJOR) -eq 8 ] && [ $(CAMLP5_MINOR) -ge 3 ]; then \
 	  printf "\nPatching bin/ged2gwb/dune.in and ged2gwb.ml for camlp5 version $(CAMLP5_VERSION) (>= 8.03.00)… Done.\n"; \
 	  perl -pi.bak -e 's|\(preprocess \(action \(run camlp5o pr_o.cmo pa_extend.cmo q_MLast.cmo %\{input-file\}\)\)\)|\(preprocess \(action \(run not-ocamlfind preprocess -package camlp5.extend,camlp5.quotations,camlp5.pr_o -syntax camlp5o %\{input-file\}\)\)\)|' bin/ged2gwb/dune.in; \
 	  perl -0777 -pi.bak -e 's/(; Token\.tok_comm = None)(\n  \})/$$1\n  ; Token.kwds = Hashtbl.create 10$$2/' bin/ged2gwb/ged2gwb.ml; \
@@ -92,12 +92,12 @@ UNPATCH = $(MAKE) --no-print-directory unpatch_files
 unpatch_after = (($(1) && $(UNPATCH)) || ($(UNPATCH) && false))
 
 info:
-	@printf "Building \033[1;1mGeneweb $(VERSION)\033[0m with $(OCAMLV).\n\n"
-	@printf "Repository \033[1;1m$(SOURCE)\033[0m. Branch \033[1;1m$(BRANCH)\033[0m. "
-	@printf "Last commit \033[1;1m$(COMMIT_ID)\033[0m message:\n\n"
-	@printf "  \033[1;1m%s\033[0m\n" '$(subst ','\'',$(COMMIT_TITLE))'
-	@if [ -n "$(COMMIT_COMMENT)" ]; then printf "  %s\n" '$(subst ','\'',$(COMMIT_COMMENT))' | fmt -w 80; fi
-	@printf "\n\033[1;1mGenerating configuration files\033[0m\n"
+	@printf 'Building \033[1;1mGeneweb $(VERSION)\033[0m with $(OCAMLV).\n\n'
+	@printf 'Repository \033[1;1m$(SOURCE)\033[0m. Branch \033[1;1m$(BRANCH)\033[0m. '
+	@printf 'Last commit \033[1;1m$(COMMIT_ID)\033[0m message:\n\n'
+	@printf '  \033[1;1m%s\033[0m\n' '$(subst ','\'',$(COMMIT_TITLE))'
+	@if [ -n '$(COMMIT_COMMENT)' ]; then printf "  %s\n" '$(subst ','\'',$(COMMIT_COMMENT))' | fmt -w 80; fi
+	@printf '\n\033[1;1mGenerating configuration files\033[0m\n'
 .PHONY: patch_files unpatch_files info
 
 GENERATED_FILES_DEP = \


### PR DESCRIPTION
This PR cleans up a bit the different workflows of the CI:
- bump the version of the GitHub action `setup-ocaml`. The latest stable version is v3 and uses opam 2.2.
- remove `opam depext` commands. External dependencies are now managed by `opam install` directly.
- use everywhere `make fmt` instead of `opam exec -- dune @fmt`. It is better to use everywhere a target from the Makefile (if the target exists) and actually the target `fmt` runs `dune @fmt --auto-promote`.
- use the OCAMLYES environment variable. It is simpler than using `-y` everywhere.
- use `opam install . --deps-only --with-test` to install all the dependencies of GeneWeb.