### PR TITLE
Add Windows and macOS in the opam CI

### DIFF
--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -26,25 +26,25 @@ jobs:
         with:
           ocaml-compiler: 5
 
-      - name: Install perl-IPC-System-Simple
+      - name: Install Cygwin Dependencies
         if: runner.os == 'Windows'
-        shell: bash
+        shell: powershell
         run: |
-          /cygdrive/c/.opam/.cygwin\setup-x86_64.exe \
-            --root "C:\\.opam\\.cygwin\\root" \
-            --quiet-mode noinput \
-            --no-shortcuts \
-            --no-startmenu \
-            --no-desktop \
-            --no-admin \
-            --no-version-check \
-            --no-write-registry \
-            --packages perl-IPC-System-Simple \
-            --symlink-type native \
-            --upgrade-also \
-            --only-site \
-            --site https://cygwin.mirror.constant.com/ \
-            --local-package-dir "C:\\.opam\\.cygwin\\cache"
+          & "C:\.opam\.cygwin\setup-x86_64.exe" `
+            --root "C:\.opam\.cygwin\root" `
+            --quiet-mode noinput `
+            --no-shortcuts `
+            --no-startmenu `
+            --no-desktop `
+            --no-admin `
+            --no-version-check `
+            --no-write-registry `
+            --packages "perl-IPC-System-Simple" `
+            --symlink-type native `
+            --upgrade-also `
+            --only-site `
+            --site "https://cygwin.mirror.constant.com/" `
+            --local-package-dir "C:\.opam\.cygwin\cache"
 
       - name: Install geneweb-compat
         run: opam install ./geneweb-compat.opam

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -50,7 +50,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          perl -MCPAN -e CPAN::Shell->notest('install', 'String::ShellQuote')
+          perl -MCPAN -e "CPAN::Shell->notest('install', 'String::ShellQuote')"
 
       - name: Install geneweb-compat
         run: opam install ./geneweb-compat.opam

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -12,7 +12,11 @@ env:
 
 jobs:
   opam:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, macos-26, windows-2022]
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -46,6 +46,12 @@ jobs:
             --site "https://cygwin.mirror.constant.com/" `
             --local-package-dir "C:\.opam\.cygwin\cache"
 
+      - name: Install String::ShellQuote
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          perl -MCPAN -e CPAN::Shell->notest('install', 'String::ShellQuote')
+
       - name: Install geneweb-compat
         run: opam install ./geneweb-compat.opam
 

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -26,6 +26,26 @@ jobs:
         with:
           ocaml-compiler: 5
 
+      - name: Install perl-IPC-System-Simple
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          C:\.opam\.cygwin\setup-x86_64.exe \
+            --root "C:\\.opam\\.cygwin\\root" \
+            --quiet-mode noinput \
+            --no-shortcuts \
+            --no-startmenu \
+            --no-desktop \
+            --no-admin \
+            --no-version-check \
+            --no-write-registry \
+            --packages perl-IPC-System-Simple \
+            --symlink-type native \
+            --upgrade-also \
+            --only-site \
+            --site https://cygwin.mirror.constant.com/ \
+            --local-package-dir "C:\\.opam\\.cygwin\\cache"
+
       - name: Install geneweb-compat
         run: opam install ./geneweb-compat.opam
 

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -30,7 +30,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          C:\.opam\.cygwin\setup-x86_64.exe \
+          /cygdrive/c/.opam/.cygwin\setup-x86_64.exe \
             --root "C:\\.opam\\.cygwin\\root" \
             --quiet-mode noinput \
             --no-shortcuts \

--- a/dune-project
+++ b/dune-project
@@ -27,6 +27,7 @@
     (camlp5 (>= "8.03.00"))
     camlp-streams
     cppo
+    (cmdliner (>= "2.1.1"))
     decompress
     fmt
     logs
@@ -87,7 +88,7 @@
     lwt
     lwt_ppx
     tls
-    (cmdliner (>= "2.0.0"))
+    (cmdliner (>= "2.1.1"))
     logs
     digestif
     httpun

--- a/geneweb-rpc.opam
+++ b/geneweb-rpc.opam
@@ -17,7 +17,7 @@ depends: [
   "lwt"
   "lwt_ppx"
   "tls"
-  "cmdliner" {>= "2.0.0"}
+  "cmdliner" {>= "2.1.1"}
   "logs"
   "digestif"
   "httpun"

--- a/geneweb.opam
+++ b/geneweb.opam
@@ -21,6 +21,7 @@ depends: [
   "camlp5" {>= "8.03.00"}
   "camlp-streams"
   "cppo"
+  "cmdliner" {>= "2.1.1"}
   "decompress"
   "fmt"
   "logs"


### PR DESCRIPTION
Testing opam installation on Linux only wasn't sufficient to catch annoying issues on Windows. This commit adds both Windows and macOS in this CI.

I also bump the minimal version of cmdliner to 2.1.1 as this version contains important fixes for Windows.